### PR TITLE
Default value of swipe direction should be circular instead of horizontal.

### DIFF
--- a/knoblibrary/src/main/java/it/beppi/knoblibrary/Knob.java
+++ b/knoblibrary/src/main/java/it/beppi/knoblibrary/Knob.java
@@ -421,13 +421,13 @@ public class Knob extends View {
         typedArray.recycle();
     }
     int swipeAttrToInt(String s) {
-        if (s == null) return 2;
+        if (s == null) return 4;
         if (s.equals("0")) return 0;
         else if (s.equals("1")) return 1;  // vertical
-        else if (s.equals("2")) return 2;  // default  - horizontal
+        else if (s.equals("2")) return 2;  // horizontal
         else if (s.equals("3")) return 3;  // both
-        else if (s.equals("4")) return 4;  // circular
-        else return 2;
+        else if (s.equals("4")) return 4;  // default  - circular
+        else return 4;
     }
     int balloonAnimationAttrToInt(String s) {
         if (s == null) return 0;


### PR DESCRIPTION
The default value _4 (circular)_ for the swipe direction is always overridden by the XML attributes to _2 (horizontal)_ if no value is manually set. The default swipe direction should be _4 (circular)_ and not _2 (horizontal)_. (See comment of [line 301](https://github.com/Thomas-Vos/Knob/blob/7e626f16a69b3af0a36cc09cf49e61cc3a958722/knoblibrary/src/main/java/it/beppi/knoblibrary/Knob.java#L301)). This pull request should solve issue #6.

Thanks for this library, it's really useful!